### PR TITLE
Fix SQLite CGO support in Docker - tested and working

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.22-alpine AS builder
 
-# Install git (needed for some Go modules)
-RUN apk add --no-cache git
+# Install build dependencies for CGO (needed for SQLite)
+RUN apk add --no-cache git gcc musl-dev
 
 # Set working directory
 WORKDIR /app
@@ -15,8 +15,8 @@ RUN go mod download
 # Copy source code
 COPY . .
 
-# Build the application (targeting the correct main file)
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o main ./cmd/server
+# Build the application with CGO enabled for SQLite
+RUN CGO_ENABLED=1 GOOS=linux go build -a -ldflags '-linkmode external -extldflags "-static"' -o main ./cmd/server
 
 # Final stage
 FROM alpine:latest


### PR DESCRIPTION
- Enable CGO with build dependencies (gcc, musl-dev)
- Static linking for portable binary
- Tested locally: API starts, database works, scheduler runs
- Ready for Railway deployment